### PR TITLE
Upload excel to drive

### DIFF
--- a/utils/excel_manager.py
+++ b/utils/excel_manager.py
@@ -3,6 +3,8 @@ import logging
 import pandas as pd
 import json
 
+from .drive_uploader import upload_to_drive
+
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
 class ExcelManager:
@@ -10,6 +12,8 @@ class ExcelManager:
 
     def __init__(self):
         os.makedirs(self.EXPORT_FOLDER, exist_ok=True)
+        self.EXPORT_PATH = os.path.join(self.EXPORT_FOLDER, "dati_clinici.xlsx")
+        self.DRIVE_META_PATH = self.EXPORT_PATH + ".drive.json"
 
     @staticmethod
     def normalize_key(key: str) -> str:
@@ -33,6 +37,7 @@ class ExcelManager:
             with pd.ExcelWriter(self.EXPORT_PATH, engine='openpyxl') as writer:
                 # Crea un foglio temporaneo per evitare errori openpyxl
                 pd.DataFrame({"temp": [None]}).to_excel(writer, sheet_name="temp", index=False)
+            self._upload_to_drive()
         logging.info(f"Created new Excel template at {self.EXPORT_PATH}")
 
     def update_excel(self, patient_id: str, document_type: str, estratti: dict):
@@ -85,6 +90,7 @@ class ExcelManager:
         with pd.ExcelWriter(self.EXPORT_PATH, engine='openpyxl') as writer:
             for sname, sdf in all_sheets.items():
                 sdf.to_excel(writer, sheet_name=sname, index=False)
+        self._upload_to_drive()
 
     def build_excel_from_uploads(self, uploads_dir="uploads"):
         """
@@ -125,7 +131,18 @@ class ExcelManager:
                 columns = sorted(doc_keys[tipo_doc])
                 df = pd.DataFrame(rows, columns=columns)
                 df.to_excel(writer, sheet_name=tipo_doc, index=False)
+        self._upload_to_drive()
         print(f"Creato Excel dinamico in {self.EXPORT_PATH}")
+
+    def _upload_to_drive(self):
+        drive_id = os.getenv("DRIVE_EXPORT_FOLDER_ID")
+        if drive_id:
+            try:
+                meta = upload_to_drive(self.EXPORT_PATH, drive_id)
+                with open(self.DRIVE_META_PATH, "w", encoding="utf-8") as md:
+                    json.dump(meta, md, indent=2, ensure_ascii=False)
+            except Exception as e:
+                logging.warning(f"Drive upload failed for {self.EXPORT_PATH}: {e}")
 
     def export_excel_file(self) -> str:
         """


### PR DESCRIPTION
## Summary
- Define EXPORT_PATH and metadata path during ExcelManager initialization
- Upload generated Excel file to Google Drive after creation and updates, storing returned Drive metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894b5262e988323b2bf7f2c16ff3056