### PR TITLE
Ensure Drive folders and upload metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from flask_cors import CORS
 import io
 import json
 import pdfplumber
-from datetime import datetime
 
 # Configura logging
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s')
@@ -224,12 +223,6 @@ def upload_document():
 
             # Lettura anagrafica iniziale
             provided_anagraphic = document_controller.file_manager.read_existing_entities(patient_id_final, "lettera_dimissione") if document_type != "lettera_dimissione" else None
-
-            # Metadata
-            meta = {"filename": filename, "upload_date": datetime.now().strftime("%Y-%m-%d")}
-            with open(filepath + ".meta.json", "w", encoding="utf-8") as mf:
-                json.dump(meta, mf)
-            app.logger.info(f"Metadata salvato per: {filename}")
 
             # Processing async
             document_controller.process_document_and_entities(

--- a/utils/drive_uploader.py
+++ b/utils/drive_uploader.py
@@ -1,8 +1,11 @@
 # utils/drive_uploader.py
+import io
+import mimetypes
 import os
+
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
-from googleapiclient.http import MediaFileUpload
+from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
 # Scope per upload “file.only”
 SCOPES = ['https://www.googleapis.com/auth/drive.file']
@@ -15,18 +18,63 @@ creds = service_account.Credentials.from_service_account_file(
 drive_service = build('drive', 'v3', credentials=creds)
 
 def upload_to_drive(local_path: str, drive_folder_id: str) -> dict:
+    """Carica il file su Google Drive nella cartella specificata.
+
+    Ritorna il dict con 'id' e 'webViewLink'. Il tipo MIME viene
+    determinato automaticamente in base all'estensione del file.
     """
-    Carica il file su Google Drive nella cartella specificata.
-    Ritorna il dict con 'id' e 'webViewLink'.
-    """
+
     file_metadata = {
-        'name': os.path.basename(local_path),
-        'parents': [drive_folder_id]
+        "name": os.path.basename(local_path),
+        "parents": [drive_folder_id],
     }
-    media = MediaFileUpload(local_path, mimetype='application/pdf')
-    file = drive_service.files().create(
-        body=file_metadata,
-        media_body=media,
-        fields='id, webViewLink'
-    ).execute()
+    mime_type = mimetypes.guess_type(local_path)[0] or "application/octet-stream"
+    media = MediaFileUpload(local_path, mimetype=mime_type)
+    file = (
+        drive_service.files()
+        .create(body=file_metadata, media_body=media, fields="id, webViewLink")
+        .execute()
+    )
     return file
+
+
+def ensure_folder(name: str, parent_id: str) -> str:
+    """Restituisce l'ID di una cartella esistente o la crea."""
+
+    query = (
+        f"'{parent_id}' in parents and name='{name}' and "
+        "mimeType='application/vnd.google-apps.folder' and trashed=false"
+    )
+    result = (
+        drive_service.files()
+        .list(q=query, fields="files(id)", spaces="drive")
+        .execute()
+    )
+    files = result.get("files", [])
+    if files:
+        return files[0]["id"]
+
+    folder_metadata = {
+        "name": name,
+        "mimeType": "application/vnd.google-apps.folder",
+        "parents": [parent_id],
+    }
+    folder = (
+        drive_service.files()
+        .create(body=folder_metadata, fields="id")
+        .execute()
+    )
+    return folder["id"]
+
+
+def download_from_drive(file_id: str) -> bytes:
+    """Scarica il contenuto di un file da Drive e lo restituisce come bytes."""
+
+    request = drive_service.files().get_media(fileId=file_id)
+    fh = io.BytesIO()
+    downloader = MediaIoBaseDownload(fh, request)
+    done = False
+    while not done:
+        _, done = downloader.next_chunk()
+    fh.seek(0)
+    return fh.read()

--- a/utils/file_manager.py
+++ b/utils/file_manager.py
@@ -2,6 +2,14 @@ import os
 import json
 import shutil
 import re
+import logging
+from datetime import datetime
+
+from .drive_uploader import (
+    upload_to_drive,
+    ensure_folder,
+    download_from_drive,
+)
 
 class FileManager:
 
@@ -12,22 +20,38 @@ class FileManager:
         os.makedirs(self.UPLOAD_FOLDER, exist_ok=True)
     
     def save_file(self, patient_id: str, document_type: str, filename: str, file_stream) -> str:
-        # 1) crea cartella
+        # 1) crea cartella locale
         folder = os.path.join(self.UPLOAD_FOLDER, patient_id, document_type)
         os.makedirs(folder, exist_ok=True)
+
         # 2) scrivi su disco
         filepath = os.path.join(folder, filename)
         with open(filepath, "wb") as f:
             f.write(file_stream.read())
-        # 3) upload su Drive
-        drive_id = os.getenv("DRIVE_FOLDER_ID")
-        if drive_id:
+
+        # 3) metadati
+        meta = {"filename": filename, "upload_date": datetime.now().strftime("%Y-%m-%d")}
+        meta_path = filepath + ".meta.json"
+        with open(meta_path, "w", encoding="utf-8") as mf:
+            json.dump(meta, mf, indent=2, ensure_ascii=False)
+
+        # 4) upload su Drive
+        drive_root_id = os.getenv("DRIVE_FOLDER_ID")
+        if drive_root_id:
             try:
-                meta = upload_to_drive(filepath, drive_id)
+                patient_folder_id = ensure_folder(patient_id, drive_root_id)
+                doc_folder_id = ensure_folder(document_type, patient_folder_id)
+                # Upload PDF
+                pdf_meta = upload_to_drive(filepath, doc_folder_id)
                 with open(filepath + ".drive.json", "w", encoding="utf-8") as md:
-                    json.dump(meta, md, indent=2, ensure_ascii=False)
+                    json.dump(pdf_meta, md, indent=2, ensure_ascii=False)
+                # Upload meta.json
+                meta_drive = upload_to_drive(meta_path, doc_folder_id)
+                with open(meta_path + ".drive.json", "w", encoding="utf-8") as md:
+                    json.dump(meta_drive, md, indent=2, ensure_ascii=False)
             except Exception as e:
                 logging.warning(f"Drive upload fallito per {filepath}: {e}")
+
         return filepath
 
 
@@ -50,14 +74,37 @@ class FileManager:
         os.makedirs(document_folder, exist_ok=True)
         output_path = os.path.join(document_folder, "entities.json")
         entities_obj = self._entities_list_to_dict(entities)
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(entities_obj, f, indent=2, ensure_ascii=False)
+
+        drive_root_id = os.getenv("DRIVE_FOLDER_ID")
+        if drive_root_id:
+            try:
+                patient_folder_id = ensure_folder(patient_id, drive_root_id)
+                doc_folder_id = ensure_folder(document_type, patient_folder_id)
+                drive_meta = upload_to_drive(output_path, doc_folder_id)
+                with open(output_path + ".drive.json", "w", encoding="utf-8") as md:
+                    json.dump(drive_meta, md, indent=2, ensure_ascii=False)
+            except Exception as e:
+                logging.warning(f"Drive upload fallito per {output_path}: {e}")
 
     def read_existing_entities(self, patient_id: str, document_type: str):
         json_path = os.path.join(self.UPLOAD_FOLDER, patient_id, document_type, "entities.json")
         if os.path.exists(json_path):
-            with open(json_path) as f:
-                return json.load(f) 
+            with open(json_path, encoding="utf-8") as f:
+                return json.load(f)
+
+        drive_meta_path = json_path + ".drive.json"
+        if os.path.exists(drive_meta_path):
+            try:
+                with open(drive_meta_path, encoding="utf-8") as df:
+                    meta = json.load(df)
+                    file_id = meta.get("id")
+                if file_id:
+                    content = download_from_drive(file_id)
+                    return json.loads(content.decode("utf-8"))
+            except Exception as e:
+                logging.warning(f"Impossibile leggere entities da Drive: {e}")
         return []
 
     def list_existing_patients(self):
@@ -163,6 +210,16 @@ class FileManager:
                                 status = "processed"
                         except Exception:
                             pass
+                    drive_meta_path = os.path.join(doc_type_path, file + ".drive.json")
+                    drive_id = drive_link = None
+                    if os.path.exists(drive_meta_path):
+                        try:
+                            with open(drive_meta_path) as dm:
+                                dmeta = json.load(dm)
+                                drive_id = dmeta.get("id")
+                                drive_link = dmeta.get("webViewLink")
+                        except Exception:
+                            pass
                     # id documento: doc_{patient_id}_{doc_type}_{filename senza estensione}
                     doc_id = f"doc_{patient_id}_{doc_type}_{os.path.splitext(filename)[0]}"
                     documents.append({
@@ -171,7 +228,9 @@ class FileManager:
                         "document_type": doc_type,
                         "upload_date": upload_date,
                         "entities_count": entities_count,
-                        "status": status
+                        "status": status,
+                        "drive_id": drive_id,
+                        "drive_link": drive_link,
                     })
         return {
             "id": patient_id,
@@ -232,30 +291,52 @@ class FileManager:
         if not pdf_file:
             return None
 
-        pdf_path = f"/uploads/{patient_id}/{document_type}/{pdf_file}"
+        drive_meta_path = os.path.join(folder, pdf_file + ".drive.json")
+        drive_id = drive_link = None
+        if os.path.exists(drive_meta_path):
+            try:
+                with open(drive_meta_path) as dm:
+                    dmeta = json.load(dm)
+                    drive_id = dmeta.get("id")
+                    drive_link = dmeta.get("webViewLink")
+            except Exception:
+                pass
 
         # Leggi entities.json
         entities = []
         entities_path = os.path.join(folder, "entities.json")
+        data = None
         if os.path.exists(entities_path):
             with open(entities_path) as f:
                 data = json.load(f)
-                if isinstance(data, dict):
-                    for idx, (k, v) in enumerate(data.items(), 1):
-                        entities.append({
-                            "id": str(idx),
-                            "type": k,
-                            "value": v,
-                            "confidence": 1.0
-                        })
-                elif isinstance(data, list):
-                    for idx, ent in enumerate(data, 1):
-                        entities.append({
-                            "id": str(idx),
-                            "type": ent.get("type") or ent.get("entità") or "",
-                            "value": ent.get("value") or ent.get("valore") or "",
-                            "confidence": ent.get("confidence", 1.0)
-                        })
+        else:
+            drive_epath = entities_path + ".drive.json"
+            if os.path.exists(drive_epath):
+                try:
+                    with open(drive_epath) as df:
+                        dmeta = json.load(df)
+                        file_id = dmeta.get("id")
+                    if file_id:
+                        content = download_from_drive(file_id)
+                        data = json.loads(content.decode("utf-8"))
+                except Exception:
+                    pass
+        if isinstance(data, dict):
+            for idx, (k, v) in enumerate(data.items(), 1):
+                entities.append({
+                    "id": str(idx),
+                    "type": k,
+                    "value": v,
+                    "confidence": 1.0,
+                })
+        elif isinstance(data, list):
+            for idx, ent in enumerate(data, 1):
+                entities.append({
+                    "id": str(idx),
+                    "type": ent.get("type") or ent.get("entità") or "",
+                    "value": ent.get("value") or ent.get("valore") or "",
+                    "confidence": ent.get("confidence", 1.0),
+                })
 
         # Leggi meta.json per recuperare il nome file originale
         filename = pdf_file
@@ -273,8 +354,9 @@ class FileManager:
             "patient_id": patient_id,
             "document_type": document_type,
             "filename": filename,
-            "pdf_path": pdf_path,
-            "entities": entities
+            "drive_id": drive_id,
+            "drive_link": drive_link,
+            "entities": entities,
         }
 
     def update_document_entities(self, document_id, entities):
@@ -323,6 +405,17 @@ class FileManager:
             # Scrive il file
             with open(entities_path, "w", encoding="utf-8") as f:
                 json.dump(entities_obj, f, indent=2, ensure_ascii=False)
+
+            drive_root_id = os.getenv("DRIVE_FOLDER_ID")
+            if drive_root_id:
+                try:
+                    patient_folder_id = ensure_folder(patient_id, drive_root_id)
+                    doc_folder_id = ensure_folder(document_type, patient_folder_id)
+                    drive_meta = upload_to_drive(entities_path, doc_folder_id)
+                    with open(entities_path + ".drive.json", "w", encoding="utf-8") as md:
+                        json.dump(drive_meta, md, indent=2, ensure_ascii=False)
+                except Exception as e:
+                    logging.warning(f"Drive upload fallito per {entities_path}: {e}")
             return True
         except Exception as e:
             logging.exception(f"Errore in update_document_entities: {e}")


### PR DESCRIPTION
## Summary
- Add `ensure_folder` and download utilities to Drive uploader
- Save metadata and upload files and JSON to Drive folders per patient/document
- Use stored Drive IDs in entity and document retrieval

## Testing
- `python -m py_compile utils/drive_uploader.py utils/file_manager.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894b525171083238196ee9f01dde192